### PR TITLE
fix: move simplecov start to top of spec_helper to fix load issues

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,8 @@
+require 'simplecov'
+SimpleCov.start
 require "./lib/game_statistics"
 require "./lib/league_statistics"
 require "./lib/season_statistics"
 require "./lib/stat_tracker"
 require "csv"
 require "pry"
-require 'simplecov'
-SimpleCov.start


### PR DESCRIPTION
## Description

Moved SimpleCov.start to the beginning of the spec_helper file to fix load issues.

## Type of change

- [x] fix
- [ ] feat
- [ ] test
- [ ] refactor
- [ ] docs

## Checklist

- [x] code has been self reviewed
- [x] code runs without any errors
- [x] thorough testing has been implemented if adding feature
- [x] all tests pass

### Thanks!